### PR TITLE
Added support for ownCloud export

### DIFF
--- a/app/src/main/java/de/koelle/christian/trickytripper/model/ExportSettings.java
+++ b/app/src/main/java/de/koelle/christian/trickytripper/model/ExportSettings.java
@@ -19,6 +19,8 @@ public class ExportSettings {
         /***/
         K9(R.string.exportOutputChannelK9, "com.fsck.k9"),
         /***/
+        OWNCLOUD(R.string.exportOutputChannelOwncloud, "com.owncloud.android"),
+        /***/
         BOXER(R.string.exportOutputChannelBoxer, "com.boxer.email"),
         /**/
         ;

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -131,6 +131,7 @@
     <string name="exportOutputChannelEnumSave2Sd">Save to SD card</string>
     <string name="exportOutputChannelMail">Mail</string>
     <string name="exportOutputChannelDropbox" translatable="false">Dropbox</string>
+    <string name="exportOutputChannelOwncloud" translatable="false">ownCloud</string>
     <string name="exportOutputChannelEvernote" translatable="false">Evernote</string>
     <string name="exportOutputChannelBoxer" translatable="false">Boxer</string>
     <string name="exportOutputChannelK9" translatable="false">K9</string>


### PR DESCRIPTION
Hi,

as my main file sharing system is ownCloud, I added support for exporting to the ownCloud android app (https://play.google.com/store/apps/details?id=com.owncloud.android&hl=de, source available at https://github.com/owncloud/android).

regards,
Oliver
