### PR TITLE
Add autocomplete suggestions to description input

### DIFF
--- a/app/src/main/java/de/koelle/christian/trickytripper/controller/TripController.java
+++ b/app/src/main/java/de/koelle/christian/trickytripper/controller/TripController.java
@@ -1,5 +1,6 @@
 package de.koelle.christian.trickytripper.controller;
 
+import java.util.ArrayList;
 import java.util.Currency;
 import java.util.List;
 import java.util.Map;
@@ -59,6 +60,8 @@ public interface TripController extends TripResolver {
     Map<Participant, Debts> getDebts();
 
     boolean hasTripPayments(TripSummary selectedTripSummary);
+
+    ArrayList<String> getDescriptions();
 
     void safeLoadedTripIdToPrefs();
 

--- a/app/src/main/java/de/koelle/christian/trickytripper/controller/impl/TripControllerImpl.java
+++ b/app/src/main/java/de/koelle/christian/trickytripper/controller/impl/TripControllerImpl.java
@@ -122,6 +122,10 @@ public class TripControllerImpl implements TripController, TripResolver {
         return dataManager.hasTripPayments(tripSummary.getId());
     }
 
+    public ArrayList<String> getDescriptions() {
+        return dataManager.getAllPaymentDescriptionsInTrip(getTripLoaded().getId());
+    }
+
     public boolean persistParticipant(Participant participant) {
 
         boolean isNew = (1 > participant.getId());

--- a/app/src/main/java/de/koelle/christian/trickytripper/dataaccess/DataManager.java
+++ b/app/src/main/java/de/koelle/christian/trickytripper/dataaccess/DataManager.java
@@ -1,5 +1,6 @@
 package de.koelle.christian.trickytripper.dataaccess;
 
+import java.util.ArrayList;
 import java.util.Currency;
 import java.util.List;
 
@@ -37,6 +38,8 @@ public interface DataManager {
     boolean deleteParticipant(long participantId);
 
     boolean hasTripPayments(long tripId);
+
+    ArrayList<String> getAllPaymentDescriptionsInTrip(long tripId);
 
     /* ========= Exchange Rates ============ */
 

--- a/app/src/main/java/de/koelle/christian/trickytripper/dataaccess/impl/DataManagerImpl.java
+++ b/app/src/main/java/de/koelle/christian/trickytripper/dataaccess/impl/DataManagerImpl.java
@@ -182,6 +182,10 @@ public class DataManagerImpl implements DataManager {
         return (paymentDao.countPaymentsInTrip(tripId) > 0);
     }
 
+    public ArrayList<String> getAllPaymentDescriptionsInTrip(long tripId) {
+        return paymentDao.getAllPaymentDescriptionsInTrip(tripId);
+    }
+
     public Trip persistTripBySummary(TripSummary tripSummary) {
         boolean isNew = (1 > tripSummary.getId());
         Trip trip;

--- a/app/src/main/java/de/koelle/christian/trickytripper/dataaccess/impl/daos/PaymentDao.java
+++ b/app/src/main/java/de/koelle/christian/trickytripper/dataaccess/impl/daos/PaymentDao.java
@@ -86,7 +86,18 @@ public class PaymentDao {
                     + PAYMENT_TABLE_SHORTY + "." + PaymentColumns.TRIP_ID
                     + " and "
                     + TRIP_TABLE_SHORTY + "." + BaseColumns._ID + " = ?";
-    // p._id = rel.payment_id and t._id = p.trip_id and t._id = 1"
+
+    private static final String PAYMENT_DESCRIPTION_QUERY =
+            "select distinct "
+                    + PAYMENT_TABLE_SHORTY + "." + PaymentColumns.DESCRIPTION
+                    + " from " +
+                    PaymentTable.TABLE_NAME + " " + PAYMENT_TABLE_SHORTY + ", " +
+                    TripTable.TABLE_NAME + " " + TRIP_TABLE_SHORTY
+                    + " where "
+                    + TRIP_TABLE_SHORTY + "." + BaseColumns._ID + " = "
+                    + PAYMENT_TABLE_SHORTY + "." + PaymentColumns.TRIP_ID
+                    + " and "
+                    + TRIP_TABLE_SHORTY + "." + BaseColumns._ID + " = ?";
 
     private final SQLiteDatabase db;
     private final SQLiteStatement stmtInsert;
@@ -219,6 +230,21 @@ public class PaymentDao {
             c.close();
         }
         list.addAll(resultMap.values());
+        return list;
+    }
+
+    public ArrayList<String> getAllPaymentDescriptionsInTrip(long tripId) {
+        ArrayList<String> list = new ArrayList<>();
+        Cursor c = db.rawQuery(PAYMENT_DESCRIPTION_QUERY, new String[] { String.valueOf(tripId) });
+        if (c.moveToFirst()) {
+            do {
+                String paymentDescription = c.getString(0);
+                list.add(paymentDescription);
+            } while (c.moveToNext());
+        }
+        if (!c.isClosed()) {
+            c.close();
+        }
         return list;
     }
 

--- a/app/src/main/res/layout/payment_edit_view.xml
+++ b/app/src/main/res/layout/payment_edit_view.xml
@@ -141,13 +141,14 @@
                 android:layout_marginTop="16dp"
                 android:text="@string/payment_edit_view_label_description" />
 
-            <EditText
-                android:id="@+id/paymentView_editTextPaymentDescription"
+            <AutoCompleteTextView
+                android:id="@+id/paymentView_autoCompleteTextViewPaymentDescription"
                 android:layout_width="fill_parent"
                 android:layout_height="wrap_content"
                 android:layout_below="@id/paymentView_textView_label_description"
                 android:layout_marginBottom="16dp"
                 android:layout_marginLeft="15dp"
+                android:completionThreshold="1"
                 android:inputType="text"/>
 
             <TextView
@@ -155,7 +156,7 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
-                android:layout_below="@id/paymentView_editTextPaymentDescription"
+                android:layout_below="@id/paymentView_autoCompleteTextViewPaymentDescription"
                 android:text="@string/payment_edit_view_label_category" />
 
             <Spinner


### PR DESCRIPTION
During a trip, there may be multiple payments with identical
descriptions (e.g. 'errands at the supermarket'). Until now, users had
to enter the description manually every time. This change enhances the
description input with autocomplete suggestions, which are collected
from all existing payments in the trip. This way, the user can simply
select a suggestion if he wants to use the same description again.
