### PR TITLE
Issue #34: divide rest among blanks - should not consider zero as blank

### DIFF
--- a/app/src/main/java/de/koelle/christian/trickytripper/activities/PaymentEditActivity.java
+++ b/app/src/main/java/de/koelle/christian/trickytripper/activities/PaymentEditActivity.java
@@ -459,7 +459,7 @@ public class PaymentEditActivity extends AppCompatActivity implements DatePicker
         int countBlanks = 0;
         List<Participant> participantsWithBlanks = new ArrayList<>();
         for (Entry<Participant, Amount> entry : payment.getParticipantToSpending().entrySet()) {
-            if (entry.getValue().getValue() == null || entry.getValue().getValue() == 0) {
+            if (entry.getValue().getValue() == null) {
                 countBlanks = countBlanks + 1;
                 participantsWithBlanks.add(entry.getKey());
             }


### PR DESCRIPTION
To me a "0" payment means, the participant should not be considered for that specific payment. "Split rest evenly among blanks" should hence skip this entry as well as non-zero numeric values and only split among the actual blanks aka "" or null.